### PR TITLE
correct change for coffescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "co-prompt": "^1.0.0",
-    "coffee-script": "^1.10.0",
+    "coffeescript": "^1.10.0",
     "commander": "^2.9.0",
     "csv-parse": "^1.1.1",
     "csv-stringify": "^1.0.4",


### PR DESCRIPTION
CoffeeScript on NPM has moved to coffeescript (no hyphen). Please update references to coffee-script to use coffeescript instead.